### PR TITLE
For react-native 0.59, config path is relative to project root

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -46,8 +46,13 @@ module.exports = (cwd, command, flags) => {
 
     if (!command) process.exit()
 
+    const reactNativeVersion = require('react-native/package.json').version;
+    const reactNativeVersionComponents = reactNativeVersion.match(/^(\d+)\.(\d+)\.(\d+)/);
+    const configNeedsRelativePath = (reactNativeVersionComponents[1] === '0' && parseInt(reactNativeVersionComponents[2], 10) < 59);
+    const configBasePath = configNeedsRelativePath ? '../../../../' : '';
+
     exec(
-        `node node_modules/react-native/local-cli/cli.js ${command} --config ../../../../${CONFIG_FILENAME} ${flags}`,
+        `node node_modules/react-native/local-cli/cli.js ${command} --config ${configBasePath}${CONFIG_FILENAME} ${flags}`,
         { stdio: [0, 1, 2] },
     )
 }


### PR DESCRIPTION
When [the React Native CLI was moved](https://blog.callstack.io/the-react-native-cli-has-a-new-home-79b63838f0e6) from react-native core to [react-native-community/cli](https://github.com/react-native-community/cli), [the config flag path](https://github.com/react-native-community/cli/tree/master/packages/cli#--config-string) became relative to the project root.

Here, we check the version of React Native being used and send the correct version of the config flag.